### PR TITLE
Support for arbitary names on complex attributes, support for mixed queries

### DIFF
--- a/src/main/java/hiof/gruppe1/Estivate/SQLAdapters/SQLTableCalculations.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLAdapters/SQLTableCalculations.java
@@ -71,6 +71,7 @@ public class SQLTableCalculations {
         HashMap<String, String> idMap = new HashMap<>();
         idMap.put(parentId, "INTEGER");
         idMap.put(childId, "INTEGER");
+        attributes.append(String.format("\"%s\" %s,", "setter", "TEXT"));
         idMap.forEach((k,v) -> {
             attributes.append(String.format("\"%s\" %s,", k, v));
         });

--- a/src/main/java/hiof/gruppe1/Estivate/SQLAdapters/SQLTableCalculations.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLAdapters/SQLTableCalculations.java
@@ -22,6 +22,8 @@ public class SQLTableCalculations {
     private String AND = "AND ";
     private String NAME = "name ";
     private String INNER_JOIN = "INNER JOIN ";
+    private String LEFT_JOIN = "LEFT JOIN ";
+    private String RIGHT_JOIN = "RIGHT JOIN ";
     private String ON = " ON ";
     private String EQUALS =  " = ";
     private String PERIOD = ".";
@@ -154,7 +156,7 @@ public class SQLTableCalculations {
             String referenced_table = complete_name.substring(complete_name.lastIndexOf("_") + 1);
             String referencing_table = complete_name.substring(0,complete_name.indexOf("_"));
 
-            joiningTableQuery.append(INNER_JOIN);
+            joiningTableQuery.append(LEFT_JOIN);
             joiningTableQuery.append(complete_name);
             joiningTableQuery.append(ON);
             joiningTableQuery.append(complete_name);
@@ -165,7 +167,7 @@ public class SQLTableCalculations {
             joiningTableQuery.append(PERIOD);
             joiningTableQuery.append(ID);
             joiningTableQuery.append(NEW_LINE);
-            joiningTableQuery.append(INNER_JOIN);
+            joiningTableQuery.append(LEFT_JOIN);
             joiningTableQuery.append(referenced_table);
             joiningTableQuery.append(ON);
             joiningTableQuery.append(referenced_table);

--- a/src/main/java/hiof/gruppe1/Main.java
+++ b/src/main/java/hiof/gruppe1/Main.java
@@ -16,9 +16,8 @@ public class Main {
                 .build();
         Author perArne = new Author("Per Arne", "To tredjedel ved fra ORM");
         Page testPage = new Page(23, "Hello");
-        perArne.setPage(testPage);
         persist.persist(perArne);
-        ArrayList<Author> authors = persist.getAll(Author.class);
-        System.out.println(authors);
+       ArrayList<Author> authors = persist.getAll(Author.class);
+       System.out.println(authors);
     }
 }

--- a/src/main/java/hiof/gruppe1/Main.java
+++ b/src/main/java/hiof/gruppe1/Main.java
@@ -16,6 +16,7 @@ public class Main {
                 .build();
         Author perArne = new Author("Per Arne", "To tredjedel ved fra ORM");
         Page testPage = new Page(23, "Hello");
+        perArne.setFavoritePage(testPage);
         persist.persist(perArne);
        ArrayList<Author> authors = persist.getAll(Author.class);
        System.out.println(authors);

--- a/src/main/java/hiof/gruppe1/testData/Author.java
+++ b/src/main/java/hiof/gruppe1/testData/Author.java
@@ -5,14 +5,14 @@ public class Author {
     private String name;
     private String books;
 
-    private Page page;
+    private Page favoritePage;
 
-    public Page getPage() {
-        return page;
+    public Page getFavoritePage() {
+        return favoritePage;
     }
 
-    public void setPage(Page page) {
-        this.page = page;
+    public void setFavoritePage(Page favoritePage) {
+        this.favoritePage = favoritePage;
     }
 
     public Author() {


### PR DESCRIPTION
Arbitary names: Users can now name their subclasses within a class whatever they'd like, the linking table will persist the name of the setter.
Mixed queries: Allows for getting a class with different amount of complex objects, the queries themselves will now fetch both an author without a book, and one with them, for example. This was due to the use of inner joins, instead of left joins.