### PR TITLE
Table naming rework to fix joined table with multiple same-named values, groundwork for multiple of same table

### DIFF
--- a/src/main/java/hiof/gruppe1/Estivate/SQLAdapters/SQLTableCalculations.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLAdapters/SQLTableCalculations.java
@@ -16,7 +16,7 @@ import static hiof.gruppe1.Estivate.utils.simpleTypeCheck.isSimple;
 
 public class SQLTableCalculations {
     IDriverHandler driver;
-    private String CREATE_TABLE = "CREATE TABLE ";
+    private String CREATE_TABLE = "CREATE TABLE IF NOT EXISTS ";
     private String SELECT_FROM_SCHEMA = "SELECT name FROM sqlite_schema ";
     private String WHERE = "WHERE ";
     private String LIKE = "LIKE ";

--- a/src/main/java/hiof/gruppe1/Estivate/SQLAdapters/SQLTableCalculations.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLAdapters/SQLTableCalculations.java
@@ -23,9 +23,8 @@ public class SQLTableCalculations {
     private String NOT_LIKE = "NOT LIKE ";
     private String AND = "AND ";
     private String NAME = "name ";
-    private String INNER_JOIN = "INNER JOIN ";
     private String LEFT_JOIN = "LEFT JOIN ";
-    private String RIGHT_JOIN = "RIGHT JOIN ";
+    private String UNDERSCORE = "_";
     private String ON = " ON ";
     private String EQUALS =  " = ";
     private String PERIOD = ".";
@@ -40,9 +39,10 @@ public class SQLTableCalculations {
 
     private HashMap<String, String> getWriteDescription(SQLWriteObject writeObject) {
         HashMap<String, String> writeObjectDescription = new HashMap<>();
+        String tableName = writeObject.getAttributeList().get("class").getInnerClass();
         writeObject.getAttributeList().forEach((k, v) -> {
             if(isSimple(v.getData().getClass())) {
-                writeObjectDescription.put(k, convertToSQLDialect(v.getData().getClass(), driver.getDialect()));
+                writeObjectDescription.put(tableName + "_" + k, convertToSQLDialect(v.getData().getClass(), driver.getDialect()));
             }
         });
         return writeObjectDescription;
@@ -92,7 +92,7 @@ public class SQLTableCalculations {
         });
 
         idMap.forEach((k,v) -> {
-            foreignKeys.append(String.format(" FOREIGN KEY (%s) REFERENCES %s (%s) ON DELETE CASCADE", k, k.toLowerCase(), "id"));
+            foreignKeys.append(String.format(" FOREIGN KEY (\"%s\") REFERENCES %s (\"%s_%s\") ON DELETE CASCADE", k, k, k, "id"));
         });
 
         joiningString.append(CREATE_TABLE);
@@ -115,7 +115,7 @@ public class SQLTableCalculations {
         StringBuilder query = new StringBuilder();
 
         String TABLE_NAME = String.format("\"%s\" ", tableName);
-        String PRIMARY_KEY = "PRIMARY KEY(\"id\" AUTOINCREMENT)";
+        String PRIMARY_KEY = String.format("PRIMARY KEY(\"%s_%s\" AUTOINCREMENT)", tableName, "id");
 
         tableAttributes.forEach((k,v) -> {
             attributes.append(String.format("\"%s\" %s,", k.toString(), v.toString()));
@@ -168,7 +168,7 @@ public class SQLTableCalculations {
         connectedTables.forEach((complete_name) -> {
             String referenced_table = complete_name.substring(complete_name.lastIndexOf("_") + 1);
             String referencing_table = complete_name.substring(0,complete_name.indexOf("_"));
-
+            // Joining Table
             joiningTableQuery.append(LEFT_JOIN);
             joiningTableQuery.append(complete_name);
             joiningTableQuery.append(ON);
@@ -178,13 +178,20 @@ public class SQLTableCalculations {
             joiningTableQuery.append(EQUALS);
             joiningTableQuery.append(referencing_table);
             joiningTableQuery.append(PERIOD);
+            joiningTableQuery.append(referencing_table);
+            joiningTableQuery.append(UNDERSCORE);
             joiningTableQuery.append(ID);
+
+
+            // Right-Table
             joiningTableQuery.append(NEW_LINE);
             joiningTableQuery.append(LEFT_JOIN);
             joiningTableQuery.append(referenced_table);
             joiningTableQuery.append(ON);
             joiningTableQuery.append(referenced_table);
             joiningTableQuery.append(PERIOD);
+            joiningTableQuery.append(referenced_table);
+            joiningTableQuery.append(UNDERSCORE);
             joiningTableQuery.append(ID);
             joiningTableQuery.append(EQUALS);
             joiningTableQuery.append(complete_name);
@@ -201,6 +208,8 @@ public class SQLTableCalculations {
         difference.forEach((name,type) -> {
             alterOperation.append("\n");
             alterOperation.append(ADD);
+            alterOperation.append(tableName);
+            alterOperation.append(".");
             alterOperation.append(name);
             alterOperation.append(" ");
             alterOperation.append(type);

--- a/src/main/java/hiof/gruppe1/Estivate/SQLAdapters/SQLTableCalculations.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLAdapters/SQLTableCalculations.java
@@ -208,8 +208,6 @@ public class SQLTableCalculations {
         difference.forEach((name,type) -> {
             alterOperation.append("\n");
             alterOperation.append(ADD);
-            alterOperation.append(tableName);
-            alterOperation.append(".");
             alterOperation.append(name);
             alterOperation.append(" ");
             alterOperation.append(type);

--- a/src/main/java/hiof/gruppe1/Estivate/SQLParsers/SQLParserTextConcatenation.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLParsers/SQLParserTextConcatenation.java
@@ -204,6 +204,7 @@ public class SQLParserTextConcatenation implements ISQLParser {
         relationshipInsert.append(" ");
         relationshipInsert.append(FROM);
         relationshipInsert.append("tempRelations");
+        relationshipInsert.append(";");
 
         return relationshipInsert.toString();
     }

--- a/src/main/java/hiof/gruppe1/Estivate/SQLParsers/SQLParserTextConcatenation.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLParsers/SQLParserTextConcatenation.java
@@ -111,7 +111,7 @@ public class SQLParserTextConcatenation implements ISQLParser {
 
     private String createWritableSQLString(SQLWriteObject writeObject) {
         tableManagement.createOrResizeTableIfNeeded(writeObject);
-
+        String tableName = writeObject.getAttributeList().get("class").getInnerClass();
         if (writeObject.getAttributeList().get("id").getData().toString().equals("0")) {
             writeObject.getAttributeList().remove("id");
         }
@@ -138,7 +138,11 @@ public class SQLParserTextConcatenation implements ISQLParser {
         finalString.append(insertTable);
 
         writeObject.getAttributeList().forEach((k, v) -> {
+            keyString.append("\"");
+            keyString.append(tableName);
+            keyString.append("_");
             keyString.append(k);
+            keyString.append("\"");
             keyString.append(",");
             valuesString.append(createWritableValue(v));
             valuesString.append(",");
@@ -180,13 +184,11 @@ public class SQLParserTextConcatenation implements ISQLParser {
 
     private String createRelationshipInsert(String setter, String parentId, String childId) {
         StringBuilder relationshipInsert = new StringBuilder();
-        StringBuilder keys = new StringBuilder();
-        keys.append(parentId);
-        keys.append(",");
-        keys.append(childId);
-        keys.append(",");
-        keys.append("setter");
-        keys.append(" ");
+        ArrayList<String> keyValues = new ArrayList<>();
+        keyValues.add(parentId);
+        keyValues.add(childId);
+        keyValues.add("setter");
+        StringBuilder keys = createCommaValues(keyValues);
 
         relationshipInsert.append("\n");
         relationshipInsert.append(INSERT_INTO);
@@ -209,7 +211,12 @@ public class SQLParserTextConcatenation implements ISQLParser {
         return relationshipInsert.toString();
     }
 
-
+    private StringBuilder createCommaValues(ArrayList<String> values) {
+        StringBuilder sb = new StringBuilder();
+        values.forEach((v) -> sb.append(String.format("\"%s\", ", v)));
+        sb.deleteCharAt(sb.length() - 1);
+        return sb;
+    }
     private String createValuesInParenthesis(StringBuilder keyString) {
         StringBuilder finalString = new StringBuilder();
         finalString.append("(");
@@ -226,18 +233,19 @@ public class SQLParserTextConcatenation implements ISQLParser {
         return sqlAttr.getData().toString();
     }
 
-    private static HashMap<String, SQLAttribute> getAttributeMap(HashMap<String, String> describedTable, ResultSet querySet) {
+    private static HashMap<String, SQLAttribute> getAttributeMap(HashMap<String, String> describedTable, ResultSet querySet, String tableName) {
         HashMap<String, SQLAttribute> readAttributes = new HashMap<>();
         try {
             for (Map.Entry<String, String> entry : describedTable.entrySet()) {
                 String attributeName = entry.getKey();
                 String attributeValue = entry.getValue();
+                String cleanAttributeName = attributeName.substring(attributeName.indexOf("_") + 1);
                 switch (getCompatAttr(attributeValue)) {
-                    case INT_COMPAT -> readAttributes.put(attributeName, new SQLAttribute(Integer.class, querySet.getInt(attributeName)));
-                    case STRING_COMPAT -> readAttributes.put(attributeName, new SQLAttribute(String.class, querySet.getString(attributeName)));
-                    case BOOLEAN_COMPAT -> readAttributes.put(attributeName, new SQLAttribute(Boolean.class, querySet.getBoolean(attributeName)));
-                    case DOUBLE_COMPAT -> readAttributes.put(attributeName, new SQLAttribute(Double.class, querySet.getDouble(attributeName)));
-                    case FLOAT_COMPAT -> readAttributes.put(attributeName, new SQLAttribute(Float.class, querySet.getFloat(attributeName)));
+                    case INT_COMPAT -> readAttributes.put(cleanAttributeName, new SQLAttribute(Integer.class, querySet.getInt(attributeName)));
+                    case STRING_COMPAT -> readAttributes.put(cleanAttributeName, new SQLAttribute(String.class, querySet.getString(attributeName)));
+                    case BOOLEAN_COMPAT -> readAttributes.put(cleanAttributeName, new SQLAttribute(Boolean.class, querySet.getBoolean(attributeName)));
+                    case DOUBLE_COMPAT -> readAttributes.put(cleanAttributeName, new SQLAttribute(Double.class, querySet.getDouble(attributeName)));
+                    case FLOAT_COMPAT -> readAttributes.put(cleanAttributeName, new SQLAttribute(Float.class, querySet.getFloat(attributeName)));
                 }
             }
         } catch (Exception e) {
@@ -256,9 +264,9 @@ public class SQLParserTextConcatenation implements ISQLParser {
     }
 
     private HashMap<String, SQLAttribute> getAttributeMap(Class topLevelCast, ArrayList<String> RelatedTables, HashMap<String, String> describedTable, ResultSet querySet) {
-        HashMap<String, SQLAttribute> readAttributes = getAttributeMap(describedTable, querySet);
+        HashMap<String, SQLAttribute> readAttributes = getAttributeMap(describedTable, querySet, topLevelCast.getSimpleName());
         for(String relatedTable : RelatedTables) {
-            HashMap<String, SQLAttribute> subElementMap = getAttributeMap(sqlDriver.describeTable(relatedTable), querySet);
+            HashMap<String, SQLAttribute> subElementMap = getAttributeMap(sqlDriver.describeTable(relatedTable), querySet, relatedTable);
             try {
                 String topLevelCastingElement = topLevelCast.getName();
                 String fullPath = topLevelCastingElement.substring(0, topLevelCastingElement.lastIndexOf(".") + 1);

--- a/src/main/java/hiof/gruppe1/Estivate/drivers/SQLiteDriver.java
+++ b/src/main/java/hiof/gruppe1/Estivate/drivers/SQLiteDriver.java
@@ -33,8 +33,8 @@ public class SQLiteDriver implements IDriverHandler {
             // This is to no massively complicate the code with calculating the most optimal
             // action, and instead recreating objects when needed.
 
-            Statement respectConstraints = connection.createStatement();
-            respectConstraints.executeUpdate("PRAGMA foreign_keys = ON;");
+            Statement pragmaSettings = connection.createStatement();
+            pragmaSettings.executeUpdate("PRAGMA foreign_keys = ON;");
         } catch (SQLException e) {
             System.out.println(e.getMessage());
         }

--- a/src/main/java/hiof/gruppe1/Estivate/drivers/SQLiteDriver.java
+++ b/src/main/java/hiof/gruppe1/Estivate/drivers/SQLiteDriver.java
@@ -56,7 +56,7 @@ public class SQLiteDriver implements IDriverHandler {
                 executeStatement.execute();
             }
         } catch (SQLException e) {
-            System.out.println(e.getMessage());
+            e.printStackTrace();
         }
     }
 

--- a/src/main/java/hiof/gruppe1/Main.java
+++ b/src/main/java/hiof/gruppe1/Main.java
@@ -14,13 +14,20 @@ public class Main {
                 setDBUrl("src/main/java/resources/estivateSQLite.db")
                 .setDebug(false)
                 .build();
-        Author perArne = new Author("Per Arne", "To tredjedel ved fra ORM");
-        Author perPer = new Author();
-        perPer.setName("Per Per");
+        Author perArne = new Author("Per Arne", "To tredjedel");
         Page testPage = new Page(23, "Hello");
+        Page testPage2 = new Page(24, "Hi");
         perArne.setFavoritePage(testPage);
+        perArne.setLeastFavoritePage(testPage2);
+
+        Author perPer = new Author();
+        Author perSecret = new Author("Per Secret", "sss");
+        perPer.setName("Per Per");
+
+        perSecret.setSecret("EEE");
         persist.persist(perPer);
         persist.persist(perArne);
+        persist.persist(perSecret);
        ArrayList<Author> authors = persist.getAll(Author.class);
        System.out.println(authors);
     }

--- a/src/main/java/hiof/gruppe1/testData/Author.java
+++ b/src/main/java/hiof/gruppe1/testData/Author.java
@@ -4,8 +4,18 @@ public class Author {
     private int id;
     private String name;
     private String books;
-
+    private String secret;
     private Page favoritePage;
+
+    private Page leastFavoritePage;
+
+    public Page getLeastFavoritePage() {
+        return leastFavoritePage;
+    }
+
+    public void setLeastFavoritePage(Page leastFavoritePage) {
+        this.leastFavoritePage = leastFavoritePage;
+    }
 
     public Page getFavoritePage() {
         return favoritePage;
@@ -45,5 +55,13 @@ public class Author {
 
     public void setBooks(String books) {
         this.books = books;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
     }
 }


### PR DESCRIPTION
Fixes an issue where a join would have multiple ids with no prefixing, meaning the first ID in the row is read, rather than the most applicable.
Some groundwork to support joining multiple of same table. Writing works, but either the multiple table of same ID need to be handled via recurring calls for the objects in question (slower due to multiple SQL calls), or we could handle it by letting the Java world decide if the following object is the same based on ID match, and then build on the object in subsequent iterations.
I feel like nr 2 is the better, or at least most applicable to current structure as is, but would nevertheless take a bit of work.