### PR TITLE
Added error ignore driver function for when we use a function we know could fail without issue

### DIFF
--- a/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/SQLParserTextConcatenation.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/SQLParserTextConcatenation.java
@@ -103,7 +103,7 @@ public class SQLParserTextConcatenation implements ISQLParser {
 
 
     private <T> int getChildId(Class<T> parentClass, int parentId, String setter, Class<?> childClass) {
-        try (ResultSet resultSet = sqlDriver.executeQuery(readBuilder.getIdOfSubElement(setter, childClass.getSimpleName(), parentClass.getSimpleName(), parentId))) {
+        try (ResultSet resultSet = sqlDriver.executeQueryIgnoreNoTable(readBuilder.getIdOfSubElement(setter, childClass.getSimpleName(), parentClass.getSimpleName(), parentId))) {
             if(resultSet != null) {
                 return resultSet.getInt(1);
             }

--- a/src/main/java/hiof/gruppe1/Estivate/drivers/IDriverHandler.java
+++ b/src/main/java/hiof/gruppe1/Estivate/drivers/IDriverHandler.java
@@ -7,6 +7,7 @@ public interface IDriverHandler {
     public ResultSet executeQuery(String query);
     public void executeNoReturnSplit(String query);
     public HashMap<String, String> describeTable(Class classOfTable);
+    public ResultSet executeQueryIgnoreNoTable(String query);
     public String getDialect();
 
     HashMap<String, String> describeTable(String simpleName);

--- a/src/main/java/hiof/gruppe1/Estivate/drivers/MySQLDriver.java
+++ b/src/main/java/hiof/gruppe1/Estivate/drivers/MySQLDriver.java
@@ -27,6 +27,11 @@ public class MySQLDriver implements IDriverHandler {
     }
 
     @Override
+    public ResultSet executeQueryIgnoreNoTable(String query) {
+        return null;
+    }
+
+    @Override
     public String getDialect() {
         return dialect;
     }

--- a/src/main/java/hiof/gruppe1/Estivate/drivers/SQLiteDriver.java
+++ b/src/main/java/hiof/gruppe1/Estivate/drivers/SQLiteDriver.java
@@ -60,8 +60,8 @@ public class SQLiteDriver implements IDriverHandler {
         }
     }
 
-    public ResultSet executeQuery(String query) {
-        ResultSet rs = null;
+    private ResultSet executeQueryBase(String query) throws SQLException {
+        ResultSet rs;
         String executingQuery = query;
         // Creating an empty rs is non-trivial, we instead rely on an empty search
         // Though in practice, this should be handled without hitting the database.
@@ -69,16 +69,29 @@ public class SQLiteDriver implements IDriverHandler {
             System.out.println("query: \n" + query);
             executingQuery = "SELECT 1 WHERE false";
         }
-
-        try {
-            Connection connection = connect();
-            PreparedStatement selectStatement = connection.prepareStatement(executingQuery);
-            rs = selectStatement.executeQuery();
-        } catch (SQLException e) {
-            System.out.println(e.getMessage());
-        }
+        Connection connection = connect();
+        PreparedStatement selectStatement = connection.prepareStatement(executingQuery);
+        rs = selectStatement.executeQuery();
         return rs;
     }
+
+    public ResultSet executeQuery(String query) {
+        try {
+            return executeQueryBase(query);
+        } catch (SQLException e) {
+            System.out.println(e);
+        }
+        return null;
+    }
+    public ResultSet executeQueryIgnoreNoTable(String query) {
+        try {
+           return executeQueryBase(query);
+        } catch (SQLException e) {
+        }
+        return null;
+    }
+
+
     @Override
     public HashMap<String, String> describeTable(Class classOfTable) {
        return describeTable(classOfTable.getSimpleName());

--- a/src/main/java/hiof/gruppe1/Main.java
+++ b/src/main/java/hiof/gruppe1/Main.java
@@ -23,7 +23,6 @@ public class Main {
         Food pizza = new Food();
         pizza.setName("Pizza");
         pizza.setTaste("Great");
-        perArne.setFavoriteFood(pizza);
         Author perPer = new Author();
         Author perSecret = new Author("Per Secret", "sss");
         perPer.setName("Per Per");


### PR DESCRIPTION
This is primarily for when we do selects against possible sub tables, without knowing if the joining table exists. This could be refactored to be unnecessary, but will in that case simply create more calls for checking. 