### PR TITLE
Fixed reader depth issue

### DIFF
--- a/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/ReadBuilder.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/ReadBuilder.java
@@ -52,7 +52,7 @@ public class ReadBuilder {
          selector.append(AND);
          selector.append("setter");
          selector.append(EQUALS);
-         selector.append(String.format("\"%s\"", setter));
+         selector.append(String.format("'%s'", setter));
          return selector.toString();
     }
 }


### PR DESCRIPTION
Qoutation marks around the setter = stopped working at a given length, fixed by moving to singleqoutes.