### PR TITLE
Moved write module to use returning instead of temp-joins, refactors of overall creation-flow

### DIFF
--- a/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/ReadBuilder.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/ReadBuilder.java
@@ -31,7 +31,6 @@ public class ReadBuilder {
         reader.append(SELECT_ALL_FROM);
         reader.append(queryClass.getSimpleName());
         reader.append(" ");
-        //  reader.append(tableManagement.createJoiningTables(queryClass.getSimpleName()));
         return reader.toString();
     }
 

--- a/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/SQLParserTextConcatenation.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/SQLParserTextConcatenation.java
@@ -9,6 +9,7 @@ import hiof.gruppe1.Estivate.objectParsers.IObjectParser;
 import hiof.gruppe1.Estivate.objectParsers.ReflectionParser;
 
 import static hiof.gruppe1.Estivate.SQLAdapters.TableDialectAttributeAdapter.getCompatAttr;
+import static hiof.gruppe1.Estivate.utils.simpleTypeCheck.isSimple;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -23,10 +24,13 @@ public class SQLParserTextConcatenation implements ISQLParser {
     private final WriteBuilder writeBuilder;
     private final ReadBuilder readBuilder;
 
+    private final TextConcatTableManagement tableManagement;
+
     public SQLParserTextConcatenation(IDriverHandler sqlDriver) {
         this.sqlDriver = sqlDriver;
+        this.tableManagement = new TextConcatTableManagement(sqlDriver);
         this.objectParser = new ReflectionParser();
-        this.writeBuilder = new WriteBuilder(sqlDriver, objectParser);
+        this.writeBuilder = new WriteBuilder();
         this.readBuilder = new ReadBuilder();
     }
 
@@ -39,9 +43,52 @@ public class SQLParserTextConcatenation implements ISQLParser {
     }
 
     public Boolean writeToDatabase(SQLWriteObject writeObject) {
-        String writeableString = writeBuilder.createWritableSQLString(writeObject);
+        String writeableString = writeObjectToDatabase(writeObject);
       //  sqlDriver.executeNoReturnSplit(writeableString);
         return true;
+    }
+
+    private String writeObjectToDatabase(SQLWriteObject writeObject) {
+        tableManagement.createOrResizeTableIfNeeded(writeObject);
+
+        if (writeObject.getAttributeList().get("id").getData().toString().equals("0")) {
+            writeObject.getAttributeList().remove("id");
+        }
+
+        String tableName = writeObject.getAttributeList().get("class").getInnerName();
+
+        String insertTable = getObjectClass(writeObject);
+        writeObject.getAttributeList().remove("class");
+
+        // PartBuilders to allow building the String in a non-linear way.
+        // Remove the complex objects after parsing.
+
+        SQLWriteObject writeObjectSimple = new SQLWriteObject();
+        writeObjectSimple.setAttributes((HashMap<String, SQLAttribute>) writeObject.getAttributeList().clone());
+        writeObjectSimple.getAttributeList().entrySet().removeIf(entry -> !isSimple(entry.getValue().getData().getClass()));
+
+        String finalString = writeBuilder.createInsertStatement(tableName, insertTable, writeObjectSimple);
+
+        int parentId = executeGetId(tableName, finalString);
+        traverseNonPrimitives(writeObject, tableName, parentId);
+
+        return String.valueOf(parentId);
+    }
+
+
+    private void traverseNonPrimitives(SQLWriteObject writeObject, String parentNameSimple, int parentId) {
+        writeObject.getAttributeList().forEach((k, v) -> {
+            if (!isSimple(v.getData().getClass())) {
+                HashMap<String, SQLAttribute> parsedAttributes = objectParser.parseObjectToAttributeList(v.getDataRaw());
+                SQLWriteObject recursiveObject = new SQLWriteObject(parsedAttributes);
+                String objectClass = getObjectClass(recursiveObject);
+
+                tableManagement.createAppendingTableIfMissing(parentNameSimple, objectClass, true);
+                String childId = writeObjectToDatabase(recursiveObject);
+                String recursiveRelationship = writeBuilder.createRelationshipInsert(k, parentNameSimple, objectClass, String.valueOf(parentId), childId);
+                sqlDriver.executeNoReturnSplit(recursiveRelationship);
+            }
+        });
     }
 
     public <T> T readFromDatabase(Class<T> castTo, int id) {
@@ -65,7 +112,6 @@ public class SQLParserTextConcatenation implements ISQLParser {
 
         return object;
     }
-
 
     public <T> ArrayList<T> readFromDatabase(Class<T> castTo) {
         String SQLQuery = readBuilder.createReadableSQLString(castTo);
@@ -125,5 +171,17 @@ public class SQLParserTextConcatenation implements ISQLParser {
             return -1;
         }
         return -1;
+    }
+
+    private int executeGetId(String tableName, String executingString) {
+        int id;
+        try {
+            ResultSet rs = sqlDriver.executeQuery(executingString);
+            id = rs.getInt(tableName + "_" + "id");
+            rs.close();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return id;
     }
 }

--- a/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/SQLParserTextConcatenation.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/SQLParserTextConcatenation.java
@@ -51,16 +51,10 @@ public class SQLParserTextConcatenation implements ISQLParser {
 
         HashMap<String, SQLAttribute> readAttributes = getAttributeMap(describedTable, querySet);
         HashMap<String, SQLAttribute> attributeHashMap = getAttributeMap(describedTable, querySet);
+
+        int parentId = attributeHashMap.get("id").getData();
+
         T object = objectParser.parseAttributeListToObject(castTo, readAttributes);
-        int parentId;
-
-        if(!attributeHashMap.isEmpty()) {
-            parentId = attributeHashMap.get("id").getData();
-            return object;
-        } else {
-            parentId = -1;
-        }
-
         HashMap<String, Class<?>> subElementList = objectParser.getSubElementList(object);
         subElementList.forEach((k,v) -> {
             int childId = getChildId(castTo, parentId, k, v);
@@ -71,6 +65,7 @@ public class SQLParserTextConcatenation implements ISQLParser {
 
         return object;
     }
+
 
     public <T> ArrayList<T> readFromDatabase(Class<T> castTo) {
         String SQLQuery = readBuilder.createReadableSQLString(castTo);

--- a/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/SQLParserTextConcatenation.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/SQLParserTextConcatenation.java
@@ -56,17 +56,10 @@ public class SQLParserTextConcatenation implements ISQLParser {
         }
 
         String tableName = writeObject.getAttributeList().get("class").getInnerName();
-
         String insertTable = getObjectClass(writeObject);
         writeObject.getAttributeList().remove("class");
 
-        // PartBuilders to allow building the String in a non-linear way.
-        // Remove the complex objects after parsing.
-
-        SQLWriteObject writeObjectSimple = new SQLWriteObject();
-        writeObjectSimple.setAttributes((HashMap<String, SQLAttribute>) writeObject.getAttributeList().clone());
-        writeObjectSimple.getAttributeList().entrySet().removeIf(entry -> !isSimple(entry.getValue().getData().getClass()));
-
+        SQLWriteObject writeObjectSimple = createCopyNonPrimitives(writeObject);
         String finalString = writeBuilder.createInsertStatement(tableName, insertTable, writeObjectSimple);
 
         int parentId = executeGetId(tableName, finalString);
@@ -74,7 +67,6 @@ public class SQLParserTextConcatenation implements ISQLParser {
 
         return String.valueOf(parentId);
     }
-
 
     private void traverseNonPrimitives(SQLWriteObject writeObject, String parentNameSimple, int parentId) {
         writeObject.getAttributeList().forEach((k, v) -> {
@@ -183,5 +175,11 @@ public class SQLParserTextConcatenation implements ISQLParser {
             throw new RuntimeException(e);
         }
         return id;
+    }
+
+    private SQLWriteObject createCopyNonPrimitives(SQLWriteObject completeObject) {
+        SQLWriteObject simple = new SQLWriteObject(new HashMap<>(completeObject.getAttributeList()));
+        simple.getAttributeList().entrySet().removeIf(entry -> !isSimple(entry.getValue().getData().getClass()));
+        return simple;
     }
 }

--- a/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/SQLParserTextConcatenation.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/SQLParserTextConcatenation.java
@@ -40,7 +40,7 @@ public class SQLParserTextConcatenation implements ISQLParser {
 
     public Boolean writeToDatabase(SQLWriteObject writeObject) {
         String writeableString = writeBuilder.createWritableSQLString(writeObject);
-        sqlDriver.executeNoReturnSplit(writeableString);
+      //  sqlDriver.executeNoReturnSplit(writeableString);
         return true;
     }
 
@@ -51,10 +51,16 @@ public class SQLParserTextConcatenation implements ISQLParser {
 
         HashMap<String, SQLAttribute> readAttributes = getAttributeMap(describedTable, querySet);
         HashMap<String, SQLAttribute> attributeHashMap = getAttributeMap(describedTable, querySet);
-
-        int parentId = attributeHashMap.get("id").getData();
-
         T object = objectParser.parseAttributeListToObject(castTo, readAttributes);
+        int parentId;
+
+        if(!attributeHashMap.isEmpty()) {
+            parentId = attributeHashMap.get("id").getData();
+            return object;
+        } else {
+            parentId = -1;
+        }
+
         HashMap<String, Class<?>> subElementList = objectParser.getSubElementList(object);
         subElementList.forEach((k,v) -> {
             int childId = getChildId(castTo, parentId, k, v);

--- a/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/TextConcatTableManagement.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/TextConcatTableManagement.java
@@ -45,10 +45,17 @@ public class TextConcatTableManagement {
         });
         return writeObjectDescription;
     }
-
-    public String createAppendingTableIfMissing(String parentClass, SQLWriteObject recursiveObject) {
-        return doesRelationExist(parentClass, getObjectClass(recursiveObject)) ?
-                createJoiningSyntax(parentClass, getObjectClass(recursiveObject)) : "";
+    public String createAppendingTableIfMissing(String parentClass, String recursiveClass) {
+        return doesRelationExist(parentClass, recursiveClass) ?
+                createJoiningSyntax(parentClass, recursiveClass) : "";
+    }
+    public void createAppendingTableIfMissing(String parentClass, String recursiveClass, Boolean execute) {
+        if(execute) {
+            String appendingTableString = createAppendingTableIfMissing(parentClass, recursiveClass);
+            if(!appendingTableString.isEmpty()) {
+                driver.executeNoReturn(appendingTableString);
+            }
+        }
     }
 
     public Boolean doesRelationExist(String parentId, String childId) {

--- a/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/WriteBuilder.java
+++ b/src/main/java/hiof/gruppe1/Estivate/SQLParsers/TextConcatenation/WriteBuilder.java
@@ -5,6 +5,8 @@ import hiof.gruppe1.Estivate.Objects.SQLWriteObject;
 import hiof.gruppe1.Estivate.drivers.IDriverHandler;
 import hiof.gruppe1.Estivate.objectParsers.IObjectParser;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -12,41 +14,14 @@ import static hiof.gruppe1.Estivate.SQLParsers.TextConcatenation.SQLParserTextCo
 import static hiof.gruppe1.Estivate.utils.simpleTypeCheck.isSimple;
 
 public class WriteBuilder {
-    private final String SELECT = "SELECT ";
-    private final String FROM = "FROM ";
     private final String INSERT_INTO = "INSERT OR REPLACE INTO ";
     private final String VALUES = " VALUES ";
     private final TextConcatTableManagement tableManagement;
     private final IObjectParser objectParser;
-    private final String SET_PARENT = " SET parent ";
-    private final String SET_CHILD = " SET child ";
-
-
-    private String set_parent(String parent_id) {
-        return "\nUPDATE " + "tempRelations_" + parent_id + SET_PARENT + "= last_insert_rowid();";
-    }
-    private String set_child(String parent_id) {
-        return "\nUPDATE " + "tempRelations_" + parent_id + SET_CHILD + "= last_insert_rowid();";
-    }
-    private String set_recursive_child(String parentTable, String childTable) {
-        String recursive_select_child = "\n" +
-                "UPDATE " +
-                "tempRelations_" +
-                parentTable +
-                SET_CHILD +
-                "= (" +
-                SELECT +
-                "MAX(" +
-                childTable +
-                "_id" +
-                ")" +
-                " FROM " +
-                childTable +
-                ");";
-        return recursive_select_child;
-    }
+    IDriverHandler driver;
 
     public WriteBuilder(IDriverHandler driver, IObjectParser objectParser) {
+        this.driver = driver;
         this.tableManagement = new TextConcatTableManagement(driver);
         this.objectParser = objectParser;
     }
@@ -54,34 +29,55 @@ public class WriteBuilder {
     String createWritableSQLString(SQLWriteObject writeObject) {
         tableManagement.createOrResizeTableIfNeeded(writeObject);
 
-        String tableName = writeObject.getAttributeList().get("class").getInnerName();
-
         if (writeObject.getAttributeList().get("id").getData().toString().equals("0")) {
             writeObject.getAttributeList().remove("id");
         }
+
+        String tableName = writeObject.getAttributeList().get("class").getInnerName();
 
         String insertTable = getObjectClass(writeObject);
         writeObject.getAttributeList().remove("class");
 
         // PartBuilders to allow building the String in a non-linear way.
+        // Remove the complex objects after parsing.
+
+        SQLWriteObject writeObjectSimple = new SQLWriteObject();
+        writeObjectSimple.setAttributes((HashMap<String, SQLAttribute>) writeObject.getAttributeList().clone());
+        writeObjectSimple.getAttributeList().entrySet().removeIf(entry -> !isSimple(entry.getValue().getData().getClass()));
+
+        String finalString = createInsertStatement(tableName, insertTable, writeObjectSimple);
+
+        int parentId = executeGetId(tableName, finalString);
+        traverseNonPrimitives(writeObject, tableName, parentId);
+
+        return String.valueOf(parentId);
+    }
+
+    private void traverseNonPrimitives(SQLWriteObject writeObject, String parentNameSimple, int parentId) {
+        writeObject.getAttributeList().forEach((k, v) -> {
+            if (!isSimple(v.getData().getClass())) {
+                HashMap<String, SQLAttribute> parsedAttributes = objectParser.parseObjectToAttributeList(v.getDataRaw());
+                SQLWriteObject recursiveObject = new SQLWriteObject(parsedAttributes);
+                String objectClass = getObjectClass(recursiveObject);
+
+                tableManagement.createAppendingTableIfMissing(parentNameSimple, objectClass, true);
+                String childId = createWritableSQLString(recursiveObject);
+                String recursiveRelationship = createRelationshipInsert(k, parentNameSimple, objectClass, String.valueOf(parentId), childId);
+                driver.executeNoReturnSplit(recursiveRelationship);
+            }
+        });
+    }
+
+    private String createInsertStatement(String tableName, String insertTable, SQLWriteObject writeObjectSimple) {
         StringBuilder finalString = new StringBuilder();
         StringBuilder keyString = new StringBuilder();
         StringBuilder valuesString = new StringBuilder();
-        StringBuilder recursiveAdds = traverseNonPrimitives(writeObject, tableName);
-        // Remove the complex objects after parsing.
-        writeObject.getAttributeList().entrySet().removeIf(entry -> !isSimple(entry.getValue().getData().getClass()));
-
-        if(!recursiveAdds.isEmpty()) {
-            String TEMP_JOINING_TABLE = "CREATE TEMP TABLE IF NOT EXISTS tempRelations_" + tableName +  " (Id PRIMARY KEY, parent INTEGER, child INTEGER); \n" +
-                    "INSERT OR IGNORE INTO tempRelations_" + tableName +  " VALUES (0,0,0); \n";
-            finalString.append(TEMP_JOINING_TABLE);
-        }
 
         // Appends
         finalString.append(INSERT_INTO);
         finalString.append(insertTable);
 
-        writeObject.getAttributeList().forEach((k, v) -> {
+        writeObjectSimple.getAttributeList().forEach((k, v) -> {
             keyString.append("\"");
             keyString.append(tableName);
             keyString.append("_");
@@ -95,71 +91,52 @@ public class WriteBuilder {
         finalString.append(StringUtils.createValuesInParenthesis(keyString));
         finalString.append(VALUES);
         finalString.append(StringUtils.createValuesInParenthesis(valuesString));
+        finalString.append(" RETURNING ");
+        finalString.append(tableName);
+        finalString.append("_");
+        finalString.append("id");
         finalString.append(";");
-        if(!recursiveAdds.isEmpty()) {
-            finalString.append(set_parent(tableName));
-        }
-        finalString.append(recursiveAdds);
 
         return finalString.toString();
     }
 
-    private StringBuilder traverseNonPrimitives(SQLWriteObject writeObject, String parentNameSimple) {
-        StringBuilder recursiveAdds = new StringBuilder();
-
-        writeObject.getAttributeList().forEach((k, v) -> {
-            if (!isSimple(v.getData().getClass())) {
-                HashMap<String, SQLAttribute> parsedAttributes = objectParser.parseObjectToAttributeList(v.getDataRaw());
-                SQLWriteObject recursiveObject = new SQLWriteObject(parsedAttributes);
-                String recursiveRelationship = createRelationshipInsert(k, parentNameSimple, getObjectClass(recursiveObject));
-                String appendingTable = tableManagement.createAppendingTableIfMissing(parentNameSimple, recursiveObject);
-                Boolean willCascade = objectParser.hasSubElements(recursiveObject.getAttributeList().get("class").getFullName());
-
-                recursiveAdds.append("\n");
-                recursiveAdds.append(appendingTable);
-                recursiveAdds.append("\n");
-                String writableSQLString = createWritableSQLString(recursiveObject);
-                recursiveAdds.append(writableSQLString);
-                if(!willCascade) {
-                    recursiveAdds.append(set_child(parentNameSimple));
-                }
-                else {
-                    recursiveAdds.append(set_recursive_child(parentNameSimple, v.getData().getClass().getSimpleName()));
-                }
-
-                recursiveAdds.append(recursiveRelationship);
-            }
-        });
-        return recursiveAdds;
+    private int executeGetId(String tableName, String executingString) {
+        int id;
+        try {
+            ResultSet rs = driver.executeQuery(executingString);
+            id = rs.getInt(tableName + "_" + "id");
+            rs.close();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return id;
     }
 
-    private String createRelationshipInsert(String setter, String parentId, String childId) {
+
+    private String createRelationshipInsert(String setter, String parentName, String childName, String parentId, String childId) {
         StringBuilder relationshipInsert = new StringBuilder();
         ArrayList<String> keyValues = new ArrayList<>();
-        keyValues.add(parentId);
-        keyValues.add(childId);
+
+        keyValues.add(parentName);
+        keyValues.add(childName);
         keyValues.add("setter");
         StringBuilder keys = StringUtils.createCommaValues(keyValues);
 
+        ArrayList<String> values = new ArrayList<>();
+        values.add(parentId);
+        values.add(childId);
+        values.add(setter);
+        StringBuilder csvValues = StringUtils.createCommaValues(values);
+
         relationshipInsert.append("\n");
         relationshipInsert.append(INSERT_INTO);
-        relationshipInsert.append(parentId);
+        relationshipInsert.append(parentName);
         relationshipInsert.append("_has_");
-        relationshipInsert.append(childId);
+        relationshipInsert.append(childName);
         relationshipInsert.append(StringUtils.createValuesInParenthesis(keys));
         relationshipInsert.append(" ");
-        relationshipInsert.append(SELECT);
-        relationshipInsert.append("parent");
-        relationshipInsert.append(",");
-        relationshipInsert.append("child");
-        relationshipInsert.append(",");
-        relationshipInsert.append(String.format("\"%s\"", setter));
-        relationshipInsert.append(" ");
-        relationshipInsert.append(FROM);
-        relationshipInsert.append("tempRelations");
-        relationshipInsert.append("_");
-        relationshipInsert.append(parentId);
-        relationshipInsert.append(";");
+        relationshipInsert.append(VALUES);
+        relationshipInsert.append(StringUtils.createValuesInParenthesis(csvValues));
 
         return relationshipInsert.toString();
     }

--- a/src/main/java/hiof/gruppe1/Estivate/drivers/IDriverHandler.java
+++ b/src/main/java/hiof/gruppe1/Estivate/drivers/IDriverHandler.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 
 public interface IDriverHandler {
     public ResultSet executeQuery(String query);
+    public void executeNoReturn(String query);
     public void executeNoReturnSplit(String query);
     public HashMap<String, String> describeTable(Class classOfTable);
     public ResultSet executeQueryIgnoreNoTable(String query);

--- a/src/main/java/hiof/gruppe1/Estivate/drivers/MySQLDriver.java
+++ b/src/main/java/hiof/gruppe1/Estivate/drivers/MySQLDriver.java
@@ -17,6 +17,11 @@ public class MySQLDriver implements IDriverHandler {
     }
 
     @Override
+    public void executeNoReturn(String query) {
+
+    }
+
+    @Override
     public void executeNoReturnSplit(String query) {
 
     }

--- a/src/main/java/hiof/gruppe1/Estivate/drivers/SQLiteDriver.java
+++ b/src/main/java/hiof/gruppe1/Estivate/drivers/SQLiteDriver.java
@@ -61,6 +61,19 @@ public class SQLiteDriver implements IDriverHandler {
             e.printStackTrace();
         }
     }
+    public void executeNoReturn(String query) {
+        if(debug) {
+            System.out.println("query: \n" + query);
+            return;
+        }
+        try {
+            Connection connection = connect();
+            PreparedStatement executeStatement = connection.prepareStatement(query);
+            executeStatement.execute();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
 
     private ResultSet executeQueryBase(String query) throws SQLException {
         ResultSet rs;

--- a/src/main/java/hiof/gruppe1/Main.java
+++ b/src/main/java/hiof/gruppe1/Main.java
@@ -24,6 +24,7 @@ public class Main {
         Author perPer = new Author();
         Author perSecret = new Author("Per Secret", "sss");
         perPer.setName("Per Per");
+        perArne.setFavoriteFood(pizza);
         AuthorList authorList = new AuthorList();
 
         authorList.setTopAuthor(perArne);

--- a/src/main/java/hiof/gruppe1/Main.java
+++ b/src/main/java/hiof/gruppe1/Main.java
@@ -33,8 +33,7 @@ public class Main {
         ALL.setAaah("EEEH");
         ALL.setAuthorList(authorList);
         persist.persist(ALL);
-        AuthorListList retrieved = persist.getOne(1, AuthorListList.class);
-        System.out.println(retrieved);
-
+        ArrayList<AuthorListList> authorListLists = persist.getAll(AuthorListList.class);
+        System.out.println(authorListLists);
     }
 }


### PR DESCRIPTION
Write module now uses returning to get and store temporary ids for joining, removing the need for temp tables and UPDATE queries on these. Should remove a large portion of writes in these cases.
The overall timing flow of writes was previously to calculate and produse one large SQL query that never needed to be returned to "higher" level modules, this "cleanliness" did provide some advantages, but ultimately caused other complexities in both computation time and overall code complexity.
With the rework of the "higher-level" write object and write recursive, these have now been cleanly split into only the write part, and the calculation part, with each seperated into their own modules.
